### PR TITLE
Simultaneous Dragging Fix

### DIFF
--- a/core/Renderer.js
+++ b/core/Renderer.js
@@ -74,5 +74,10 @@ export default class Renderer {
 
     addItem(item) {
         this.items.push(item);
+        
+        // Take responsibility for dragging
+        if (item instanceof DraggableItem) {
+            item.responsibleForMouseDown = false;
+        }
     }
 }

--- a/core/Renderer.js
+++ b/core/Renderer.js
@@ -1,3 +1,5 @@
+import DraggableItem from "./items/DraggableItem.js";
+
 /*
 * Class Renderer.
 *
@@ -7,6 +9,47 @@ export default class Renderer {
     items = [];
 
     constructor(canvas) {
+        
+        /* 
+        * Let the renderer control the passing of mousedown events to its draggable items
+        *
+        * The items of a renderer need to know about each other (e.g., they need
+        * to know which item is "on top" to know which item should be dragged),
+        * but the cleanest way to do this is to give responsibility to a parent.
+        *
+        * We'll loop through the items top-to-bottom and give them each a chance
+        * to handle the mousedown event. If one of the items handles it, then
+        * we stop giving others a chance.
+        */
+        addEventListener('mousedown', (event) => {
+            
+            // Loop through items in reverse-render-order. An item is "on top"
+            // if it's rendered last.
+            for (let index = this.items.length - 1; index >= 0; index--) {
+                
+                // Only take responsibility for draggable items
+                if (!(this.items[index] instanceof DraggableItem)) continue;
+                
+                // Pass the event to the current item and have it report whether
+                // the event was handled.
+                const eventWasHandled = this.items[index].handleMouseDown(event)
+                
+                // If the event was handled, then we need to break out of this loop
+                // (we don't want multiple items being dragged all at once!)
+                // 
+                // Additionally, dragging an item puts it "on top" of the others, so
+                // we need to change up the order of this.items
+                if (eventWasHandled) {
+                    // Send the item that handled the event to the back of this.items
+                    this.items.push(this.items.splice(index, 1)[0]);
+                    // break out of the loop to stop passing this event around
+                    break;
+                }
+                
+            }
+            
+        });
+        
         var frames = setInterval(() => {
             var ctx = canvas.getContext("2d");
 

--- a/core/items/DraggableItem.js
+++ b/core/items/DraggableItem.js
@@ -18,9 +18,10 @@ export default class DraggableItem extends Item {
         if (this.constructor == DraggableItem)
             throw new Error("Abstract classes can't be instantiated.");
             
-        this.canvas.addEventListener('mousedown', (event) => {
-            this.handleMouseDown(event);
-        });
+        // Remove mousedown responsibility
+        //this.canvas.addEventListener('mousedown', (event) => {
+        //    this.handleMouseDown(event);
+        //});
 
         this.canvas.addEventListener('mouseup', (event) => {
             this.handleMouseUp(event);
@@ -49,13 +50,18 @@ export default class DraggableItem extends Item {
         this.mouseX = parseInt(event.clientX);
         this.mouseY = parseInt(event.clientY);
 
-        // Check if mouse down inside the DraggableItem
-        if ((this.mouseX >= this.x && this.mouseX <= (this.x+this.width))
-            && (this.mouseY >= this.y && this.mouseY <= (this.y+this.height))) {
+        // Do we need to do anything? Yes, iff mouse down inside the DraggableItem
+        const handleEvent = (this.mouseX >= this.x && this.mouseX <= (this.x+this.width))
+            && (this.mouseY >= this.y && this.mouseY <= (this.y+this.height));
+        
+        if (handleEvent) {
                 this.selected = true;
                 this.offsetX = this.mouseX-this.x;
                 this.offsetY = this.mouseY-this.y;
             }
+        
+        // Report whether or not we took action on this event
+        return handleEvent;
     }
 
     handleMouseUp(event) {

--- a/core/items/DraggableItem.js
+++ b/core/items/DraggableItem.js
@@ -12,16 +12,21 @@ export default class DraggableItem extends Item {
     mouseX = null;
     mouseY = null;
     selected = false;
+    
+    // Allow containers to take responsibility for handling mousedown events,
+    // e.g., Renderer may need to determine which items it owns are to be dragged.
+    responsibleForMouseDown = true;
 
     constructor(canvas, x, y, width, height) {
         super(canvas, x, y, width, height);
         if (this.constructor == DraggableItem)
             throw new Error("Abstract classes can't be instantiated.");
-            
-        // Remove mousedown responsibility
-        //this.canvas.addEventListener('mousedown', (event) => {
-        //    this.handleMouseDown(event);
-        //});
+        
+        this.canvas.addEventListener('mousedown', (event) => {
+            if (this.responsibleForMouseDown) {
+                this.handleMouseDown(event);
+            }
+        });
 
         this.canvas.addEventListener('mouseup', (event) => {
             this.handleMouseUp(event);


### PR DESCRIPTION
## Behavior Fixes
1. Overlapping `DraggableItem`s that belong to a `Renderer` are no longer simultaneously dragged.
2. Dragging a `DraggableItem` in a `Renderer` now puts it "on top" of other items in the `Renderer`.

---

## New Behavior

By default, a `DraggableItem` will handle its own `mousedown` events, but once added to a `Renderer`, the `Renderer` will seize this responsibility.

### Simultaneous Dragging

`DraggableItem`s were being simultaneously dragged because they have no knowledge of other `DraggableItem`s in their parent `Renderer` (so, for example, they have no regard for other `DraggableItem`s that may be "on top"). Also, `DraggableItem`s are not added as DOM Elements, so we can't rely on the usual event propagation rules to handle events (instead, all `DraggableItem`s are aware of all events).

Now upon receiving an `onmousedown` event, a `Renderer` will loop through its `DraggableItem`s in reverse-render-order (i.e., an item that is rendered last/"on top" will be considered first) and give each item a chance to handle the event. Once an item takes action on the event, we stop giving other items a chance. This guarantees that an `onmousedown` event will only initiate dragging for one item and that priority is given to items that are "on top".

### Render Order

Dragging an item originally did not affect its render order (which led to flickering since `Renderer` and `DraggableItem` were calling `.render()` at incompatible times).

Dragging an item that belongs to a `Renderer` now moves the item to the end of the `Renderer`'s `items` array. Since a `Renderer` renders its items in order, this has the effect of putting the dragged item "on top" of the others. It also makes the `Renderer` and `DraggableItem` render calls compatible.